### PR TITLE
[fix] Db adapter database key name mismatch

### DIFF
--- a/src/Queue/Adapters/Db.php
+++ b/src/Queue/Adapters/Db.php
@@ -35,7 +35,7 @@ class Db implements Adapter
             'host' => $connection['host'] ?? '127.0.0.1',
             'username' => $connection['username'] ?? 'root',
             'password' => $connection['password'] ?? '',
-            'dbname' => $connection['dbname'] ?? '',
+            'dbname' => $connection['database'] ?? '',
         ]);
     }
 


### PR DESCRIPTION
## Description
Fix for the db adapter not being able to connect to the database.

## Related Issue
-